### PR TITLE
Add Traefik labels to Grafana (keep direct port)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,6 +45,10 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.grafana.rule=Host(`grafana.home`)"
+      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
     cap_drop:
       - ALL
     security_opt:


### PR DESCRIPTION
- Add Traefik routing labels for grafana.home hostname
- Keep direct port mapping (3000) for transition period
- Both access paths will work: direct port and via Traefik