### PR TITLE
Add local verification commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # home-server
 ![lint](https://github.com/AlexMikhalochkin/home-server/actions/workflows/lint-docker.yaml/badge.svg)
+
+## Local Verification
+
+Verify `docker-compose.yaml` locally using:
+
+### Docker Compose Linter (dclint)
+```bash
+docker run -t --rm -v ${PWD}:/app zavoloklom/dclint /app/docker-compose.yaml
+```
+
+### KICS Security Scanner
+```bash
+docker run -t --rm -v "./docker-compose.yaml":/path/docker-compose.yaml checkmarx/kics scan -p /path -o "/path/"
+```


### PR DESCRIPTION
This PR adds documentation for local verification commands to the README.

## Changes
- Added "Local Verification" section to README
- Documented two verification commands:
  - Docker Compose Linter (dclint)
  - KICS Security Scanner

These commands allow developers to verify `docker-compose.yaml` locally before pushing changes.